### PR TITLE
improved header text based on number of packages and repositories

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,11 +25,14 @@
 #include <QStringList>
 #include <QUuid>
 #include <QFileInfo>
+#include <QTranslator>
+#include <QLibraryInfo>
 #include "mainwindow.h"
 
 int main( int argc, char *argv[] )
 {
     QApplication app( argc, argv );
+
     bool fakeRequested = false;
     if( argc == 1) {
         qDebug() << "No Valid File Passed";
@@ -46,5 +49,10 @@ int main( int argc, char *argv[] )
     qDebug() << fileName;
     MainWindow *win = new MainWindow( QString( argv[1] ), fileName, fakeRequested );
     win->show();
+
+    QTranslator translator;
+    translator.load( "qt_" + QLocale::system().name(), QLibraryInfo::location( QLibraryInfo::TranslationsPath ) );
+    app.installTranslator( &translator );
+
     return app.exec();
 }

--- a/src/mainheader.cpp
+++ b/src/mainheader.cpp
@@ -47,12 +47,36 @@ void MainHeader::changeStatusLabel( int repoCount, int packageCount )
     m_packageCount = packageCount;
     m_repoCount = repoCount;
 
-    m_statusLabel->setText( QString( "This installer will download and install %1 packages from %2 sources" ).arg( packageCount ).arg( repoCount ) );
+    QString statusText = QString( "This installer will download and install %1" ).arg( m_packageCount );
+
+    if( m_packageCount > 1 )
+        statusText.append( " packages" );
+    else
+        statusText.append( " package" );
+
+    if( m_repoCount > 1 )
+        statusText.append( QString( " from %1 sources" ).append( m_repoCount ) );
+    else
+        statusText.append( " from 1 source");
+    m_statusLabel->setText( statusText );
 }
 
 void MainHeader::updateDetails( QString size )
 {
-    m_statusLabel->setText( QString( "This installer will download and install %1 packages from %2 sources totalling %3" ).arg( m_packageCount ).arg( m_repoCount ).arg( size ) );
+    QString statusText = QString( "This installer will download and install %1" ).arg( m_packageCount );
+
+    if( m_packageCount > 1 )
+        statusText.append( " packages" );
+    else
+        statusText.append( " package" );
+
+    if( m_repoCount > 1 )
+        statusText.append( QString( " from %1 sources" ).append( m_repoCount ) );
+    else
+        statusText.append( " from 1 source");
+    statusText.append( QString( " totalling %1" ).arg( size ) );
+
+    m_statusLabel->setText( statusText );
 }
 
 void MainHeader::installationStarted()

--- a/src/mainheader.cpp
+++ b/src/mainheader.cpp
@@ -47,17 +47,18 @@ void MainHeader::changeStatusLabel( int repoCount, int packageCount )
     m_packageCount = packageCount;
     m_repoCount = repoCount;
 
-    QString statusText = QString( "This installer will download and install %1" ).arg( m_packageCount );
+    QString statusText = QString( tr( "This installer will download and install %n package(s) ", "", m_packageCount ) );
+    statusText.append( QString( tr( "from %n source(s)", "", m_repoCount ) ) );
 
-    if( m_packageCount > 1 )
-        statusText.append( " packages" );
-    else
-        statusText.append( " package" );
+//    if( m_packageCount > 1 )
+//        statusText.append( " packages" );
+//    else
+//        statusText.append( " package" );
 
-    if( m_repoCount > 1 )
-        statusText.append( QString( " from %1 sources" ).append( m_repoCount ) );
-    else
-        statusText.append( " from 1 source");
+//    if( m_repoCount > 1 )
+//        statusText.append( QString( " from %1 sources" ).append( m_repoCount ) );
+//    else
+//        statusText.append( " from 1 source");
     m_statusLabel->setText( statusText );
 }
 

--- a/src/mainheader.cpp
+++ b/src/mainheader.cpp
@@ -47,36 +47,13 @@ void MainHeader::changeStatusLabel( int repoCount, int packageCount )
     m_packageCount = packageCount;
     m_repoCount = repoCount;
 
-    QString statusText = QString( tr( "This installer will download and install %n package(s) ", "", m_packageCount ) );
-    statusText.append( QString( tr( "from %n source(s)", "", m_repoCount ) ) );
-
-//    if( m_packageCount > 1 )
-//        statusText.append( " packages" );
-//    else
-//        statusText.append( " package" );
-
-//    if( m_repoCount > 1 )
-//        statusText.append( QString( " from %1 sources" ).append( m_repoCount ) );
-//    else
-//        statusText.append( " from 1 source");
+    QString statusText = QString( tr( "This installer will install %n package(s) %1", 0, m_packageCount ).arg( tr( "from %n source(s)", 0, m_repoCount ) ) );
     m_statusLabel->setText( statusText );
 }
 
 void MainHeader::updateDetails( QString size )
 {
-    QString statusText = QString( "This installer will download and install %1" ).arg( m_packageCount );
-
-    if( m_packageCount > 1 )
-        statusText.append( " packages" );
-    else
-        statusText.append( " package" );
-
-    if( m_repoCount > 1 )
-        statusText.append( QString( " from %1 sources" ).append( m_repoCount ) );
-    else
-        statusText.append( " from 1 source");
-    statusText.append( QString( " totalling %1" ).arg( size ) );
-
+    QString statusText = QString( tr( "This installer will install %n package(s) %1", 0, m_packageCount ).arg( tr( "from %n source(s) totalling %1", 0, m_repoCount ).arg( size ) ) );
     m_statusLabel->setText( statusText );
 }
 


### PR DESCRIPTION
When there is package or repository, header displays status as '1 package/source'
If more than 1 package or repository is being used, header displays status as 'x packages/sources'