### PR TITLE
The rest of previous commit for animated image when fetching data and better command line handling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ INSTALL(TARGETS oneclickinstaller DESTINATION /usr/bin)
 
 INSTALL(FILES oci.desktop DESTINATION /usr/share/applications)
 INSTALL(FILES res/oneclickinstall.png DESTINATION /usr/share/icons/hicolor/32x32/apps/)
+INSTALL(FILES res/ticks-endless.gif DESTINATION /usr/share/one-click-installer/res/)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}
 	${CMAKE_CURRENT_BINARY_DIR}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,20 +31,25 @@ int main( int argc, char *argv[] )
 {
     QApplication app( argc, argv );
     bool fakeRequested = false;
-    if( argc == 1) {
+    
+    QStringList args = app.arguments();
+    if (args.contains("--fake")) {
+        qDebug()<< "FakeBackend being used";
+        fakeRequested = true;
+        args.removeAll("--fake");
+    }
+    
+    if( args.isEmpty() || !QFile::exists(args[0])) {
         qDebug() << "No Valid File Passed";
         return 0;
     }
-    if( !QString( "--fake" ).compare( argv[ 2 ] ) ) {
-        qDebug()<< "FakeBackend being used";
-        fakeRequested = true;
-    }
-    QString fileName( "/tmp/" );
+    
+    QString fileName = args[0];
+    QString tmpFileName = QString( "/tmp/%1-%2" ).arg( QFileInfo( fileName ).fileName().split( "." ).at( 0 ) )
+                                                 .arg( QUuid::createUuid().toString().split( "-" ).at( 1 ) );
 
-    fileName.append( QFileInfo( argv[1] ).fileName().split( "." ).at( 0 ) ).append( "-" );
-    fileName.append( QUuid::createUuid().toString().split( "-" ).at( 1 ) );
-    qDebug() << fileName;
-    MainWindow *win = new MainWindow( QString( argv[1] ), fileName, fakeRequested );
+    qDebug() << tmpFileName;
+    MainWindow *win = new MainWindow( fileName, tmpFileName, fakeRequested );
     win->show();
     return app.exec();
 }

--- a/src/packagedetails.cpp
+++ b/src/packagedetails.cpp
@@ -32,8 +32,14 @@ PackageDetails::PackageDetails(OCI::Package *package,int count, int packagecount
     meta->getData();
 
     m_summary = new QLabel( QString( "<b>Summary:</b> %1" ).arg( package->summary() ) );
+    m_fetchingAnimation.setFileName("/usr/share/one-click-installer/res/ticks-endless.gif");
     m_version = new QLabel( "Fetching..." );
     m_size = new QLabel( "Fetching..." );
+    if (m_fetchingAnimation.isValid()) {
+       m_version->setMovie(&m_fetchingAnimation);
+       m_size->setMovie(&m_fetchingAnimation);
+       m_fetchingAnimation.start();
+    };
 
     QObject::connect( meta, SIGNAL( finished( QString,QString ) ), this, SLOT( dataChanged( QString,QString ) ) );
 

--- a/src/packagedetails.h
+++ b/src/packagedetails.h
@@ -7,6 +7,7 @@
 #include <QHash>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
+#include <QMovie>
 #include "package.h"
 #include "packagemetadata.h"
 
@@ -29,6 +30,7 @@ private:
     QLabel *m_description;
     QLabel *m_showDescription;
     QCheckBox *m_packageName;
+    QMovie m_fetchingAnimation;
 
     PackageMetadata *meta;
 


### PR DESCRIPTION
The whole commit for showing an animated image while fetching package details (since I forgot to add some files in the previous commit), and better handling of command line parameters, so that at least it's independent of the order of the flags and it's easier to add other flags in the future.