### PR TITLE
Replace System Calls with Library Calls

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,11 +22,11 @@ find_package(KF5I18n NO_MODULE)
 add_definitions(${Qt5Widgets_DEFINITIONS})
 add_definitions(${Qt5DBus_DEFINITIONS})
 
-set(oneclickinstaller_SOURCES main.cpp mainwindow.cpp firstscreen.cpp settings.cpp fakebackend.cpp repository.cpp package.cpp ympparser.cpp packagebackend.cpp installscreen.cpp repositorywidget.cpp summary.cpp backend.cpp keyringcallbacks.cpp mainheader.cpp packagedetails.cpp repositorymetadata.cpp repositorydata.cpp packagemetadata.cpp clientdbus.cpp dbusadaptor.cpp)
-set(oneclickinstaller_HEADERS mainwindow.h firstscreen.h settings.h installscreen.h repositorywidget.h summary.h mainheader.h packagedetails.h packagemetadata.h backend.h packagebackend.h dbusadaptor.h clientdbus.h)
+set(oneclickinstaller_SOURCES main.cpp utils.cpp mainwindow.cpp firstscreen.cpp settings.cpp fakebackend.cpp repository.cpp package.cpp ympparser.cpp packagebackend.cpp installscreen.cpp repositorywidget.cpp summary.cpp backend.cpp keyringcallbacks.cpp mainheader.cpp packagedetails.cpp repositorymetadata.cpp repositorydata.cpp packagemetadata.cpp clientdbus.cpp dbusadaptor.cpp)
+set(oneclickinstaller_HEADERS utils.h mainwindow.h firstscreen.h settings.h installscreen.h repositorywidget.h summary.h mainheader.h packagedetails.h packagemetadata.h backend.h packagebackend.h dbusadaptor.h clientdbus.h)
 
-set(oneclickhelper_SOURCES interfacemain.cpp backend.cpp keyringcallbacks.cpp packagebackend.cpp dbusadaptor.cpp)
-set(oneclickhelper_HEADERS backend.h packagebackend.h keyringcallbacks.h dbusadaptor.h)
+set(oneclickhelper_SOURCES interfacemain.cpp backend.cpp keyringcallbacks.cpp utils.cpp packagebackend.cpp dbusadaptor.cpp)
+set(oneclickhelper_HEADERS backend.h packagebackend.h keyringcallbacks.h utils.h dbusadaptor.h)
 
 QT5_WRAP_CPP(oneclickhelper_HEADERS_MOC ${oneclickhelper_HEADERS})
 QT5_WRAP_CPP(oneclickinstaller_HEADERS_MOC ${oneclickinstaller_HEADERS})

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -79,7 +79,7 @@ void Backend::addRepositories()
     }
 }
 
-bool Backend::exists(QString repo )
+bool Backend::exists(const QString& repo )
 {
     qDebug() << "Parameter is " << repo;
     std::list< zypp::RepoInfo > repoList = std::list< zypp::RepoInfo >( m_manager->repoBegin(), m_manager->repoEnd() );

--- a/src/backend.h
+++ b/src/backend.h
@@ -57,7 +57,7 @@ protected:
     /**
         Check if repo exists in the Repository database or not
      */
-    bool exists( QString repo );
+    bool exists( const QString& repo );
 
 
 

--- a/src/fakebackend.cpp
+++ b/src/fakebackend.cpp
@@ -50,7 +50,7 @@ void FakeBackend::callBackendHelper()
     install();
 }
 
-bool FakeBackend::exists( QString url )
+bool FakeBackend::exists( const QString& url )
 {
     return false;
 }

--- a/src/fakebackend.h
+++ b/src/fakebackend.h
@@ -31,7 +31,7 @@ class FakeBackend : public PackageBackend
     /**
         Fake Implementation of Exists function
      */
-    bool exists( QString url );
+    bool exists( const QString& url );
 
     private:
     QWidget *m_main;

--- a/src/firstscreen.cpp
+++ b/src/firstscreen.cpp
@@ -21,7 +21,7 @@
 #include "firstscreen.h"
 #include "utils.h"
 
-FirstScreen::FirstScreen( PackageBackend *backend, QString *tmpFileName, const QString& filename, QObject *parent )
+FirstScreen::FirstScreen( PackageBackend *backend, const QString& tmpFileName, const QString& filename, QObject *parent )
 {
     m_tmpFileName = tmpFileName;
     setStyleSheet( "background-color : white;" );
@@ -30,7 +30,7 @@ FirstScreen::FirstScreen( PackageBackend *backend, QString *tmpFileName, const Q
     mainLayout->setSpacing( 0 );
     setLayout( mainLayout );
 
-    QFile dataFile( m_tmpFileName->toLocal8Bit() );
+    QFile dataFile( m_tmpFileName.toLocal8Bit() );
     if( !dataFile.open( QIODevice::Truncate | QIODevice::WriteOnly ) ) {
         qDebug() << "Could not open Data File";
     }

--- a/src/firstscreen.cpp
+++ b/src/firstscreen.cpp
@@ -45,6 +45,8 @@ FirstScreen::FirstScreen( PackageBackend *backend, const QString& tmpFileName, c
 
     //Add Repository
     int i = 0;
+    m_numOfRepositories = 0;
+    m_numOfPackages = 0;
     QVBoxLayout *repoDetails;
     m_untrustedSources = 0;
     foreach( OCI::Repository *repo, m_repos) {
@@ -52,6 +54,7 @@ FirstScreen::FirstScreen( PackageBackend *backend, const QString& tmpFileName, c
         if(repo->recommended() == "false")
             continue;
         ZypperUtils::initRepository(repo->url().toStdString());
+        ++m_numOfRepositories;
         m_backend->addRepository( QUrl( repo->url() ) );
         RepositoryWidget *repositoryDetails = new RepositoryWidget( m_backend, i, m_repos.at( i ) );
         mainLayout->addWidget( repositoryDetails );
@@ -60,7 +63,8 @@ FirstScreen::FirstScreen( PackageBackend *backend, const QString& tmpFileName, c
         static int j = 0;
 	
         foreach( OCI::Package *package, m_packages ) {
-	        m_backend->addPackage( package->name() );
+            ++m_numOfPackages;
+            m_backend->addPackage( package->name() );
             mainLayout->addSpacing( -10 );
             PackageDetails *packDetails = new PackageDetails( package, j, m_packages.count() );
             QObject::connect( packDetails, SIGNAL( sizeUpdated( QString ) ), this, SIGNAL( sizeUpdated( QString ) ) );
@@ -92,7 +96,7 @@ FirstScreen::FirstScreen( PackageBackend *backend, const QString& tmpFileName, c
 
 void FirstScreen::showEvent( QShowEvent *s )
 {
-    emit countChanged( m_repos.count(), m_packages.count() );
+    emit countChanged( m_numOfRepositories, m_numOfPackages );
     qDebug() << "number of untrusted sources is " << m_untrustedSources;
 }
 

--- a/src/firstscreen.cpp
+++ b/src/firstscreen.cpp
@@ -47,8 +47,9 @@ FirstScreen::FirstScreen( PackageBackend *backend, const QString& tmpFileName, c
     int i = 0;
     m_numOfRepositories = 0;
     m_numOfPackages = 0;
-    QVBoxLayout *repoDetails;
     m_untrustedSources = 0;
+    unsigned int packageID = 0;
+    QVBoxLayout *repoDetails;
     foreach( OCI::Repository *repo, m_repos) {
         // Only proceed if it is the recommended repository
         if(repo->recommended() == "false")
@@ -60,17 +61,15 @@ FirstScreen::FirstScreen( PackageBackend *backend, const QString& tmpFileName, c
         mainLayout->addWidget( repositoryDetails );
         if( !m_backend->exists( repo->url() ) )
             m_untrustedSources++;
-        static int j = 0;
-	
+        
         foreach( OCI::Package *package, m_packages ) {
             ++m_numOfPackages;
             m_backend->addPackage( package->name() );
             mainLayout->addSpacing( -10 );
-            PackageDetails *packDetails = new PackageDetails( package, j, m_packages.count() );
+            PackageDetails *packDetails = new PackageDetails( package, packageID++, m_packages.count() );
             QObject::connect( packDetails, SIGNAL( sizeUpdated( QString ) ), this, SIGNAL( sizeUpdated( QString ) ) );
             QObject::connect( packDetails, SIGNAL( installableStateToggled( bool ) ), this, SLOT( checkPackagesInstallableState() ) );
             mainLayout->addWidget( packDetails );
-            j++;
         }
         i++;
         mainLayout->addSpacing( -8 );

--- a/src/firstscreen.h
+++ b/src/firstscreen.h
@@ -33,7 +33,7 @@ public:
    /**
         Default constructor taking the backend, and the filename as argument
    */
-    FirstScreen( PackageBackend *backend, QString *tmpFileName, const QString& filename, QObject *parent = 0 );
+    FirstScreen( PackageBackend *backend, const QString& tmpFileName, const QString& filename, QObject *parent = 0 );
     
 private slots:
 
@@ -51,7 +51,7 @@ private:
 
     QList< OCI::Package* > m_packages;
     QList< OCI::Repository* > m_repos;
-    QString *m_tmpFileName;
+    QString m_tmpFileName;
     QLabel *m_warning;
     int m_untrustedSources;
 

--- a/src/firstscreen.h
+++ b/src/firstscreen.h
@@ -53,7 +53,9 @@ private:
     QList< OCI::Repository* > m_repos;
     QString m_tmpFileName;
     QLabel *m_warning;
-    int m_untrustedSources;
+    unsigned int m_numOfRepositories;
+    unsigned int m_numOfPackages;
+    unsigned int m_untrustedSources;
 
 signals:
     void showNextScreen( int );

--- a/src/installscreen.cpp
+++ b/src/installscreen.cpp
@@ -21,7 +21,7 @@
 #include <klocalizedstring.h>
 #include "installscreen.h"
 
-InstallScreen::InstallScreen(PackageBackend *backend, QString *tmpFileName, QObject *parent )
+InstallScreen::InstallScreen(PackageBackend *backend, const QString& tmpFileName, QObject *parent )
 {
     setStyleSheet( "" );
     m_backend = backend;
@@ -102,7 +102,7 @@ void InstallScreen::showCompletionStatus()
     }
 }
 
-void InstallScreen::logFileChanged( QString path )
+void InstallScreen::logFileChanged( const QString& path )
 {
     qDebug() << "changed";
     QFile file( path );

--- a/src/installscreen.h
+++ b/src/installscreen.h
@@ -28,7 +28,7 @@ public:
     /**
      *  Default Constructor
      */
-    InstallScreen( PackageBackend *backend, QString *tmpFileName,  QObject *parent = 0 );
+    InstallScreen( PackageBackend *backend, const QString& tmpFileName,  QObject *parent = 0 );
 
 private slots:
     /**
@@ -36,7 +36,7 @@ private slots:
     */
     void showCompletionStatus();
 
-    void logFileChanged( QString path );
+    void logFileChanged( const QString& path );
 
     void cancelInstallation();
 
@@ -47,7 +47,7 @@ private:
     QPushButton *m_cancel;
     PackageBackend *m_backend;
 
-    QString *m_tmpFileName;
+    QString m_tmpFileName;
 
     QHash< int, QHBoxLayout* > m_packageLayouts;
     QProgressBar *m_progressBar;

--- a/src/keyring.h
+++ b/src/keyring.h
@@ -1,5 +1,5 @@
 #ifndef KEYRING_H
-#define KDERING_H
+#define KEYRING_H
 
 #include <stdlib.h>
 #include <iostream>
@@ -10,7 +10,7 @@
 #include <zypp/Pathname.h>
 #include <zypp/base/Logger.h>
 
-namespace zypp{
+using namespace zypp;
 struct KeyRingReceive : public zypp::callback::ReceiveReport<zypp::KeyRingReport>
 {
     bool m_keyRingExists;
@@ -44,6 +44,5 @@ struct KeyRingReceive : public zypp::callback::ReceiveReport<zypp::KeyRingReport
         return KeyRingReport::KEY_TRUST_AND_IMPORT;
     }
 };
-}
 
 #endif

--- a/src/keyringcallbacks.cpp
+++ b/src/keyringcallbacks.cpp
@@ -19,38 +19,40 @@
 
 
 #include "keyringcallbacks.h"
+#include "utils.h"
 
 zypp::KeyRingCallbacks::KeyRingCallbacks()
 {
-	_keyRingReport.connect();
+    temp = ZypperUtils::keyReport();
+    temp.connect();
 }
 
 zypp::KeyRingCallbacks::~KeyRingCallbacks()
 {
-	_keyRingReport.disconnect();
+    temp.disconnect();
 }
 
 bool zypp::KeyRingCallbacks::exists()
 {
-    return _keyRingReport.m_keyRingExists;
+    return temp.m_keyRingExists;
 }
 
 std::string zypp::KeyRingCallbacks::name(){
-    return _keyRingReport.m_name;
+    return temp.m_name;
 }
 
 std::string zypp::KeyRingCallbacks::id(){
-    return _keyRingReport.m_id;
+    return temp.m_id;
 }
 
 std::string zypp::KeyRingCallbacks::fingerprint(){
-    return _keyRingReport.m_fingerprint;
+    return temp.m_fingerprint;
 }
 
 std::string zypp::KeyRingCallbacks::created(){
-    return _keyRingReport.m_created;
+    return temp.m_created;
 }
 
 std::string zypp::KeyRingCallbacks::expires(){
-    return _keyRingReport.m_expires;
+    return temp.m_expires;
 }

--- a/src/keyringcallbacks.cpp
+++ b/src/keyringcallbacks.cpp
@@ -1,58 +1,64 @@
-//      Copyright 2012 Saurabh Sood <saurabh@saurabh.geeko>
-//      
-//      This program is free software; you can redistribute it and/or modify
-//      it under the terms of the GNU General Public License as published by
-//      the Free Software Foundation; either version 2 of the License, or
-//      (at your option) any later version.
-//      
-//      This program is distributed in the hope that it will be useful,
-//      but WITHOUT ANY WARRANTY; without even the implied warranty of
-//      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//      GNU General Public License for more details.
-//      
-//      You should have received a copy of the GNU General Public License
-//      along with this program; if not, write to the Free Software
-//      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-//      MA 02110-1301, USA.
-//      
-//      
-
+/***********************************************************************************
+ *  One Click Installer makes it easy for users to install software, no matter
+ *  where that software is located.
+ *
+ *  Copyright (C) 2016  Shalom <shalomray7@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ************************************************************************************
+ *  This program's developed as part of GSoC - 2016
+ *  Project: One Click Installer
+ *  Mentors: Antonio Larrosa, and Cornelius Schumacher
+ *  Organization: OpenSUSE
+ *  Previous Contributor: Saurabh Sood
+ ***********************************************************************************/
 
 #include "keyringcallbacks.h"
 #include "utils.h"
 
 zypp::KeyRingCallbacks::KeyRingCallbacks()
 {
-    temp = ZypperUtils::keyReport();
-    temp.connect();
+    m_keyReport = ZypperUtils::keyReport();
+    m_keyReport.connect();
 }
 
 zypp::KeyRingCallbacks::~KeyRingCallbacks()
 {
-    temp.disconnect();
+    m_keyReport.disconnect();
 }
 
 bool zypp::KeyRingCallbacks::exists()
 {
-    return temp.m_keyRingExists;
+    return m_keyReport.m_keyRingExists;
 }
 
 std::string zypp::KeyRingCallbacks::name(){
-    return temp.m_name;
+    return m_keyReport.m_name;
 }
 
 std::string zypp::KeyRingCallbacks::id(){
-    return temp.m_id;
+    return m_keyReport.m_id;
 }
 
 std::string zypp::KeyRingCallbacks::fingerprint(){
-    return temp.m_fingerprint;
+    return m_keyReport.m_fingerprint;
 }
 
 std::string zypp::KeyRingCallbacks::created(){
-    return temp.m_created;
+    return m_keyReport.m_created;
 }
 
 std::string zypp::KeyRingCallbacks::expires(){
-    return temp.m_expires;
+    return m_keyReport.m_expires;
 }

--- a/src/keyringcallbacks.h
+++ b/src/keyringcallbacks.h
@@ -2,7 +2,7 @@
 #define KEYRINGCALLBACKS_H
 
 #include <QDebug>
-#include <keyring.h>
+#include "keyring.h"
 
 namespace zypp {
 class KeyRingCallbacks

--- a/src/keyringcallbacks.h
+++ b/src/keyringcallbacks.h
@@ -48,7 +48,7 @@ public:
      */
      std::string expires();
 private:
-    KeyRingReceive temp;
+    KeyRingReceive m_keyReport;
  
 };
 }

--- a/src/keyringcallbacks.h
+++ b/src/keyringcallbacks.h
@@ -2,53 +2,54 @@
 #define KEYRINGCALLBACKS_H
 
 #include <QDebug>
-#include "keyring.h"
+#include <keyring.h>
 
-namespace zypp{
-class KeyRingCallbacks{
-    private:
-        zypp::KeyRingReceive _keyRingReport;
-    public:
+namespace zypp {
+class KeyRingCallbacks
+{
+public:
     /**
-		Default Constructor
-	 */
-	KeyRingCallbacks();
+     * Default Constructor
+     */
+    KeyRingCallbacks();
 
-	/**
-		Destructor
-	 */
-        ~KeyRingCallbacks();
+    /**
+    * Destructor
+    */
+    ~KeyRingCallbacks();
 
-	/**
-		Returns whether the Keyring exists or not
-	 */
-        bool exists();
+    /**
+    * Returns whether the Keyring exists or not
+    */
+    bool exists();
 
     /**
         Returns the KeyRing name
      */
-        std::string name();
+     std::string name();
 
     /**
         Returns the KeyRing ID
      */
-        std::string id();
+     std::string id();
 
     /**
         Returns the KeyRing
      */
-        std::string fingerprint();
+     std::string fingerprint();
 
     /**
         Returns the Creation Date of the Fingerprint
      */
-        std::string created();
+     std::string created();
 
     /**
         Returns the Expiry Date of the Fingerprint
      */
-        std::string expires();
+     std::string expires();
+private:
+    KeyRingReceive temp;
+ 
 };
 }
-
 #endif

--- a/src/mainheader.cpp
+++ b/src/mainheader.cpp
@@ -52,7 +52,9 @@ void MainHeader::changeStatusLabel( int repoCount, int packageCount )
 
 void MainHeader::updateDetails( const QString& size )
 {
-    m_statusLabel->setText( i18ncp( "Third argument is the total size of all packages", "This installer will download and install %1 package from %2 source totalling %3", "This installer will download and install %1 packages from %2 sources totalling %3", m_packageCount, m_repoCount, size) );
+    m_totalSize += size.split(" ").at(0).toFloat();
+    QString sizeString = (QString::number(m_totalSize)).append(size.split(" ").at(1));
+    m_statusLabel->setText( i18ncp( "Third argument is the total size of all packages", "This installer will download and install %1 package from %2 source totalling %3", "This installer will download and install %1 packages from %2 source(s) totalling %3", m_packageCount, m_repoCount, sizeString) );
 }
 
 void MainHeader::installationStarted()

--- a/src/mainheader.cpp
+++ b/src/mainheader.cpp
@@ -50,7 +50,7 @@ void MainHeader::changeStatusLabel( int repoCount, int packageCount )
     m_statusLabel->setText( i18np("This installer will download and install %1 package from %2 source", "This installer will download and install %1 packages from %2 sources", packageCount, repoCount) );
 }
 
-void MainHeader::updateDetails( QString size )
+void MainHeader::updateDetails( const QString& size )
 {
     m_statusLabel->setText( i18ncp( "Third argument is the total size of all packages", "This installer will download and install %1 package from %2 source totalling %3", "This installer will download and install %1 packages from %2 sources totalling %3", m_packageCount, m_repoCount, size) );
 }

--- a/src/mainheader.h
+++ b/src/mainheader.h
@@ -43,7 +43,7 @@ public slots:
 private:
     QLabel *m_statusLabel;
     QLabel *m_icon;
-
+    float m_totalSize;
     int m_repoCount;
     int m_packageCount;
 };

--- a/src/mainheader.h
+++ b/src/mainheader.h
@@ -21,7 +21,7 @@ public:
     /**
      *  Update the size of the packages
      */
-    void updateDetails( QString size );
+    void updateDetails( const QString& size );
 
 public slots:
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -20,7 +20,7 @@
 #include <klocalizedstring.h>
 #include "mainwindow.h"
 
-MainWindow::MainWindow( const QString& filename, QString tmpFileName, bool fakeRequested, QObject *parent )
+MainWindow::MainWindow( const QString& filename, const QString& tmpFileName, bool fakeRequested, QObject *parent )
 {
     setStyleSheet( "background-color : rgb(251,248,241)" );
     setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
@@ -44,7 +44,7 @@ MainWindow::MainWindow( const QString& filename, QString tmpFileName, bool fakeR
     QObject::connect( m_install, SIGNAL( clicked() ), this, SLOT( performInstallation() ) );
     QObject::connect( m_cancel, SIGNAL( clicked()), this, SLOT( close() ) );
 
-    m_tmpFileName = new QString( tmpFileName );
+    m_tmpFileName = tmpFileName;
     QVBoxLayout *mainLayout = new QVBoxLayout;
     m_screenStack = new QStackedLayout;
 
@@ -123,7 +123,7 @@ void MainWindow::performInstallation()
         m_screenStack->setCurrentIndex( 1 );
     } else {
         m_screenStack->setCurrentIndex( 2 );
-        m_backend->setFileName( *m_tmpFileName );
+        m_backend->setFileName( m_tmpFileName );
         m_backend->callBackendHelper();
     }
     m_install->hide();
@@ -131,7 +131,7 @@ void MainWindow::performInstallation()
     m_cancel->hide();
 }
 
-void MainWindow::updateSize( QString size )
+void MainWindow::updateSize( const QString& size )
 {
     if( m_screenStack->currentIndex() == 0 )
         m_header->updateDetails( size );

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -25,12 +25,12 @@ public:
     /**
         Default Constructor taking the YMP file as argument
     */
-    MainWindow( const QString& filename, QString tmpFileName, bool fakeRequested, QObject *parent = 0 );
+    MainWindow( const QString& filename, const QString& tmpFileName, bool fakeRequested, QObject *parent = 0 );
 
 private:
     PackageBackend *m_backend;
     FirstScreen *m_firstScreen;
-    QString *m_tmpFileName;
+    QString m_tmpFileName;
     MainHeader *m_header;
     QStackedLayout *m_screenStack;
 
@@ -69,7 +69,7 @@ private slots:
     /**
      * Update the size of packages
      */
-    void updateSize(QString size );
+    void updateSize(const QString& size );
 
 signals:
     void countChanged( int repoCount, int packageCount );

--- a/src/packagebackend.cpp
+++ b/src/packagebackend.cpp
@@ -49,7 +49,7 @@ QString PackageBackend::getFileName()
     return m_tmpFileName;
 }
 
-void PackageBackend::setFileName( QString fileName )
+void PackageBackend::setFileName( const QString& fileName )
 {
     m_tmpFileName = fileName;
 }

--- a/src/packagebackend.h
+++ b/src/packagebackend.h
@@ -47,7 +47,7 @@ class PackageBackend : public QObject
     /**
         Set the Temporary Filename
      */
-    virtual void setFileName( QString fileName );
+    virtual void setFileName( const QString& fileName );
 
     /**
         Get the Temporary Filename
@@ -57,7 +57,7 @@ class PackageBackend : public QObject
     /**
         Return true if repository exists
      */
-    virtual bool exists( QString url ) = 0;
+    virtual bool exists( const QString& url ) = 0;
 
 private:
     QList< QString > m_packages;

--- a/src/packagedetails.cpp
+++ b/src/packagedetails.cpp
@@ -29,7 +29,7 @@ PackageDetails::PackageDetails(OCI::Package *package,int count, int packagecount
     mainLayout->setSpacing( 0 );
     QHBoxLayout *packageLayout = new QHBoxLayout;
 
-    meta = new PackageMetadata( package->name() );
+    m_packageMetadata = new PackageMetadata( package->name() );
     
 
     m_summary = new QLabel( i18n("<b>Summary:</b> %1").arg(package->summary()) );
@@ -42,7 +42,7 @@ PackageDetails::PackageDetails(OCI::Package *package,int count, int packagecount
        m_fetchingAnimation.start();
     };
 
-    QObject::connect( meta, SIGNAL( finished( QString,QString ) ), this, SLOT( dataChanged( QString,QString ) ) );
+    QObject::connect( m_packageMetadata, SIGNAL( finished( QString,QString ) ), this, SLOT( dataChanged( QString,QString ) ) );
 
      m_showDescription = new QLabel( QString( "<a href = \"%1\">%2</a>" ).arg( count ).arg( i18n("Show Details") ));
     m_showDescription->setSizePolicy( QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding );

--- a/src/packagedetails.cpp
+++ b/src/packagedetails.cpp
@@ -29,7 +29,8 @@ PackageDetails::PackageDetails(OCI::Package *package,int count, int packagecount
     mainLayout->setSpacing( 0 );
     QHBoxLayout *packageLayout = new QHBoxLayout;
 
-    m_packageMetadata = new PackageMetadata( package->name() );
+    m_packageMetadata = new PackageMetadata();
+    m_packageMetadata->getData( package->name() );
     
 
     m_summary = new QLabel( i18n("<b>Summary:</b> %1").arg(package->summary()) );

--- a/src/packagedetails.cpp
+++ b/src/packagedetails.cpp
@@ -30,7 +30,7 @@ PackageDetails::PackageDetails(OCI::Package *package,int count, int packagecount
     QHBoxLayout *packageLayout = new QHBoxLayout;
 
     meta = new PackageMetadata( package->name() );
-    meta->getData();
+    
 
     m_summary = new QLabel( i18n("<b>Summary:</b> %1").arg(package->summary()) );
     m_fetchingAnimation.setFileName("/usr/share/one-click-installer/res/ticks-endless.gif");

--- a/src/packagedetails.h
+++ b/src/packagedetails.h
@@ -34,7 +34,7 @@ private:
     QCheckBox *m_packageName;
     QMovie m_fetchingAnimation;
 
-    PackageMetadata *meta;
+    PackageMetadata *m_packageMetadata;
 
 private slots:
 

--- a/src/packagemetadata.cpp
+++ b/src/packagemetadata.cpp
@@ -42,8 +42,10 @@ void PackageMetadata::getData( const QString& packageName )
     m_version = QString::fromStdString(packageObj.edition().asString());
     m_size = QString::fromStdString(packageObj.installSize().asString());
     
-    //invoke isFinished() slot manually
-    QMetaObject::invokeMethod(this, "isFinished", Qt::QueuedConnection);
+    // We use QMetaObject::invokeMethod to queue the call until the finished() signal is connected
+    // by the parent object later on in the code. Please, don't replace it with a direct call to
+    // sizeAndVersionObtained unless you really know what you're doing.
+    QMetaObject::invokeMethod(this, "sizeAndVersionObtained", Qt::QueuedConnection);
 }
 
 QString PackageMetadata::size()
@@ -56,7 +58,7 @@ QString PackageMetadata::version()
     return m_version;
 }
 
-void PackageMetadata::isFinished()
+void PackageMetadata::sizeAndVersionObtained()
 {
     qDebug() << m_size;
     qDebug() << m_version;

--- a/src/packagemetadata.cpp
+++ b/src/packagemetadata.cpp
@@ -27,7 +27,11 @@
 #include "packagemetadata.h"
 #include "utils.h"
 
-PackageMetadata::PackageMetadata( const QString& packageName )
+PackageMetadata::PackageMetadata()
+{   
+}
+
+void PackageMetadata::getData( const QString& packageName )
 {
     PoolItem packageObj = ZypperUtils::queryMetadataForPackage(packageName.toStdString());
     if (!packageObj) {
@@ -40,7 +44,6 @@ PackageMetadata::PackageMetadata( const QString& packageName )
     
     //invoke isFinished() slot manually
     QMetaObject::invokeMethod(this, "isFinished", Qt::QueuedConnection);
-   
 }
 
 QString PackageMetadata::size()

--- a/src/packagemetadata.cpp
+++ b/src/packagemetadata.cpp
@@ -1,38 +1,46 @@
-//      Copyright 2012 Saurabh Sood <saurabh@saurabh.geeko>
-//
-//      This program is free software; you can redistribute it and/or modify
-//      it under the terms of the GNU General Public License as published by
-//      the Free Software Foundation; either version 2 of the License, or
-//      (at your option) any later version.
-//
-//      This program is distributed in the hope that it will be useful,
-//      but WITHOUT ANY WARRANTY; without even the implied warranty of
-//      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//      GNU General Public License for more details.
-//
-//      You should have received a copy of the GNU General Public License
-//      along with this program; if not, write to the Free Software
-//      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-//      MA 02110-1301, USA.
-//
-//
+/***********************************************************************************
+ *  One Click Installer makes it easy for users to install software, no matter
+ *  where that software is located.
+ *
+ *  Copyright (C) 2016  Shalom <shalomray7@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ************************************************************************************
+ *  This program's developed as part of GSoC - 2016
+ *  Project: One Click Installer
+ *  Mentors: Antonio Larrosa, and Cornelius Schumacher
+ *  Organization: OpenSUSE
+ *  Previous Contributor: Saurabh Sood
+ ***********************************************************************************/
 
 #include "packagemetadata.h"
+#include "utils.h"
 
-PackageMetadata::PackageMetadata( QString name )
+PackageMetadata::PackageMetadata( const QString& packageName )
 {
-    m_package = name;
-}
-
-void PackageMetadata::getData()
-{
-    QString processName = "zypper info " + m_package;
-    qDebug() << processName;
-    m_process = new QProcess;
-    m_process->setProcessChannelMode( QProcess::MergedChannels );
-    QObject::connect( m_process, SIGNAL( finished( int ) ), this, SLOT( isFinished( int ) ) );
-    QObject::connect( m_process, SIGNAL( started() ), this, SLOT( isStarted() ) );
-    m_process->start( processName );
+    PoolItem packageObj = ZypperUtils::queryMetadataForPackage(packageName.toStdString());
+    if (!packageObj) {
+      qDebug() << "Package Not found";
+      // Will think of a way how to make user known about this
+      return;
+    }
+    m_version = QString::fromStdString(packageObj.edition().asString());
+    m_size = QString::fromStdString(packageObj.installSize().asString());
+    
+    //invoke isFinished() slot manually
+    QMetaObject::invokeMethod(this, "isFinished", Qt::QueuedConnection);
+   
 }
 
 QString PackageMetadata::size()
@@ -45,26 +53,8 @@ QString PackageMetadata::version()
     return m_version;
 }
 
-void PackageMetadata::isStarted()
+void PackageMetadata::isFinished()
 {
-    qDebug() << "zypper called";
-}
-
-void PackageMetadata::isFinished( int v )
-{
-    m_stdout = m_process->readAllStandardOutput();
-    qDebug() << "finished process";
-    QStringList details = m_stdout.split( "\n" );
-
-    foreach( QString line, details ) {
-        if( line.contains("Version") ) {
-            m_version = line.split( " " ).at( 1 );
-        } else if( line.contains( "Installed Size" ) ) {
-            QStringList size = line.split( " " );
-            m_size = size.at( 2 ) + " " + size.at( 3 );
-        }
-    }
-
     qDebug() << m_size;
     qDebug() << m_version;
 

--- a/src/packagemetadata.h
+++ b/src/packagemetadata.h
@@ -13,9 +13,9 @@ class PackageMetadata : public QObject
 public:
 
     /**
-     * Construct the Object using the name of the package
+     * Default ctor
      */
-    PackageMetadata( const QString& packageName );
+    PackageMetadata();
 
     /**
      * Return the size of the package
@@ -27,14 +27,19 @@ public:
      */
     QString version();
     
+    /**
+     * Query Metadata Information
+     */
+    void getData( const QString& packageName );
 private:
       
     QString m_size;
     QString m_version;
+    
 private slots:
-
+  
     /**
-     * Process output when subprocess finishes
+     * Emit finished signal
      */
     void isFinished();
 

--- a/src/packagemetadata.h
+++ b/src/packagemetadata.h
@@ -41,7 +41,7 @@ private slots:
     /**
      * Emit finished signal
      */
-    void isFinished();
+    void sizeAndVersionObtained();
 
 signals:
     void finished( QString version, QString size );

--- a/src/packagemetadata.h
+++ b/src/packagemetadata.h
@@ -2,9 +2,10 @@
 #define PACKAGEMETADATA_H
 
 #include <QDebug>
-#include <QProcess>
 #include <QObject>
-#include <QStringList>
+#include "repository.h"
+
+using namespace std;
 
 class PackageMetadata : public QObject
 {
@@ -14,7 +15,7 @@ public:
     /**
      * Construct the Object using the name of the package
      */
-    PackageMetadata( QString name );
+    PackageMetadata( const QString& packageName );
 
     /**
      * Return the size of the package
@@ -25,30 +26,17 @@ public:
      * Return the version of the package
      */
     QString version();
-
-    /**
-     * Start the subprocess to retrieve the data
-     */
-    void getData();
+    
 private:
+      
     QString m_size;
     QString m_version;
-    QString m_stdout;
-
-    QString m_package;
-
-    QProcess *m_process;
 private slots:
-
-    /**
-     * Check if the subprocess started
-     */
-    void isStarted();
 
     /**
      * Process output when subprocess finishes
      */
-    void isFinished( int );
+    void isFinished();
 
 signals:
     void finished( QString version, QString size );

--- a/src/repositorydata.cpp
+++ b/src/repositorydata.cpp
@@ -33,25 +33,6 @@ void RepositoryData::setBaseUrl( std::string url )
     m_baseUrl = url;
 }
 
-void RepositoryData::refreshMetadata()
-{
-    m_options = new zypp::RepoManagerOptions( "/tmp" );
-    m_repoManager = new zypp::RepoManager( *m_options );
-    m_repo.addBaseUrl( zypp::Url( m_baseUrl ) );
-    m_repo.setGpgCheck( true );
-    m_repo.setAlias( m_alias );
-    m_repo.setEnabled( true );
-    m_repo.setAutorefresh( true );
-    try{
-        m_repoManager->cleanCache( m_repo );
-        m_repoManager->refreshMetadata( m_repo );
-    } catch( zypp::repo::RepoException s) {
-        std::cout << s;
-    }
-    m_repoManager->cleanMetadata( m_repo );
-    delete m_options;
-    delete m_repoManager;
-}
 
 zypp::KeyRingCallbacks RepositoryData::keyring()
 {

--- a/src/repositorydata.cpp
+++ b/src/repositorydata.cpp
@@ -23,12 +23,12 @@ RepositoryData::RepositoryData()
 {
 }
 
-void RepositoryData::setAlias( std::string alias )
+void RepositoryData::setAlias( const std::string& alias )
 {
     m_alias = alias;
 }
 
-void RepositoryData::setBaseUrl( std::string url )
+void RepositoryData::setBaseUrl( const std::string& url )
 {
     m_baseUrl = url;
 }

--- a/src/repositorydata.h
+++ b/src/repositorydata.h
@@ -1,16 +1,4 @@
 #include <string>
-#include <zypp/Capabilities.h>
-#include <zypp/sat/WhatProvides.h>
-#include <zypp/sat/Solvable.h>
-#include <zypp/RepoManager.h>
-#include <zypp/misc/DefaultLoadSystem.h>
-#include <zypp/ZYppFactory.h>
-#include <zypp/ui/Selectable.h>
-#include <zypp/ResObject.h>
-#include <zypp/ResKind.h>
-#include <zypp/base/LogTools.h>
-#include <zypp/base/LogControl.h>
-#include <zypp/ByteCount.h>
 #include "keyringcallbacks.h"
 
 class RepositoryData
@@ -37,17 +25,9 @@ public:
      */
     zypp::KeyRingCallbacks keyring();
 
-    /**
-     * Refresh Repository Metadata
-     */
-    void refreshMetadata();
-
 private:
-    zypp::RepoManagerOptions *m_options;
-    zypp::RepoInfo m_repo;
-    zypp::RepoManager *m_repoManager;
-    zypp::KeyRingCallbacks m_keyring;
-
     std::string m_baseUrl;
     std::string m_alias;
+    
+    zypp::KeyRingCallbacks m_keyring;
 };

--- a/src/repositorydata.h
+++ b/src/repositorydata.h
@@ -13,12 +13,12 @@ public:
     /**
      * Set Base Url of Repository
      */
-    void setBaseUrl( std::string url );
+    void setBaseUrl( const std::string& url );
 
     /**
      * Set Alias of Repository
      */
-    void setAlias( std::string alias );
+    void setAlias( const std::string& alias );
 
     /**
      * Return the KeyRing

--- a/src/repositorymetadata.cpp
+++ b/src/repositorymetadata.cpp
@@ -45,8 +45,3 @@ QString RepositoryMetadata::id()
 {
     return QString::fromStdString( m_repoData->keyring().id() );
 }
-
-void RepositoryMetadata::refresh()
-{
-    m_repoData->refreshMetadata();
-}

--- a/src/repositorymetadata.h
+++ b/src/repositorymetadata.h
@@ -35,12 +35,6 @@ public:
      * Return the id
      */
     QString id();
-
-    /**
-     * Refresh Metadata
-     */
-    void refresh();
-
 private:
     RepositoryData *m_repoData;
 };

--- a/src/repositorywidget.cpp
+++ b/src/repositorywidget.cpp
@@ -70,7 +70,6 @@ void RepositoryWidget::showDetails( QString link )
 {
     if( !m_visible ) {
         m_meta = new RepositoryMetadata( m_repo );
-        m_meta->refresh();
         m_id = new QLabel( i18n("<b>ID: </b> %1").arg(m_meta->id()) );
         m_fingerprint = new QLabel( i18n("<b>Fingerprint: </b> %1").arg(m_meta->fingerprint()) );
         m_created = new QLabel( i18n("<b>Created: </b> %1").arg(m_meta->created()) );

--- a/src/summary.cpp
+++ b/src/summary.cpp
@@ -22,7 +22,7 @@
 #include <klocalizedstring.h>
 #include "summary.h"
 
-Summary::Summary(PackageBackend *backend, QString *tmpFileName, QObject *parent )
+Summary::Summary(PackageBackend *backend, const QString& tmpFileName, QObject *parent )
 {
     m_backend = backend;
     m_tmpFileName = tmpFileName;
@@ -57,7 +57,7 @@ Summary::Summary(PackageBackend *backend, QString *tmpFileName, QObject *parent 
 void Summary::continueInstallation()
 {
     emit showNextScreen( 2 );
-    m_backend->setFileName( *m_tmpFileName );
+    m_backend->setFileName( m_tmpFileName );
     m_backend->callBackendHelper();
 }
 

--- a/src/summary.h
+++ b/src/summary.h
@@ -21,7 +21,7 @@ public:
     /**
      * Construct the object with the filename and backend object
      */
-    Summary( PackageBackend *backend, QString *tmpFileName, QObject *parent = 0 );
+    Summary( PackageBackend *backend, const QString& tmpFileName, QObject *parent = 0 );
 
 private:
     QTextBrowser *m_installationSummary;
@@ -30,7 +30,7 @@ private:
     PackageBackend *m_backend;
     QProcess backendProcess;
 
-    QString *m_tmpFileName;
+    QString m_tmpFileName;
 
 private slots:
 

--- a/src/summary.h
+++ b/src/summary.h
@@ -7,7 +7,6 @@
 #include <QHBoxLayout>
 #include <QPushButton>
 #include <QList>
-#include <QProcess>
 #include <QScrollBar>
 #include <cstdlib>
 #include "packagebackend.h"
@@ -28,7 +27,6 @@ private:
     QPushButton *m_continue;
     QPushButton *m_cancel;
     PackageBackend *m_backend;
-    QProcess backendProcess;
 
     QString m_tmpFileName;
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -32,20 +32,20 @@
 
 /************************************* ZypperUtils Class **************************************/
 // Define static variables here
-RepoManagerOptions* ZypperUtils::rOpts = new RepoManagerOptions("/tmp");
-RepoManager* ZypperUtils::repoManager = new RepoManager(*rOpts);
+RepoManagerOptions* ZypperUtils::s_repoManagerOpts = new RepoManagerOptions("/tmp");
+RepoManager* ZypperUtils::s_repoManager = new RepoManager(*s_repoManagerOpts);
 PoolItem ZypperUtils::mainObject;
-KeyRingReceive ZypperUtils::_keyReport;
+KeyRingReceive ZypperUtils::s_keyReceiveReport;
 
 //Methods
 
 void ZypperUtils::initRepository( const string& repoUrl )
 {
     //KeyRing - Handling of gpg keys
-    _keyReport.connect();
+    s_keyReceiveReport.connect();
     refreshRepoManager( initRepoInfo( repoUrl ) );
-    _keyReport.disconnect();
-    RepoInfo info = repoManager->getRepo( repoUrl );
+    s_keyReceiveReport.disconnect();
+    RepoInfo info = s_repoManager->getRepo( repoUrl );
     cout << "===================================================" << endl;
     cout << "Alias: " << info.alias() << endl;
     cout << "Url: " << info.url() << endl;
@@ -65,8 +65,8 @@ RepoInfo ZypperUtils::initRepoInfo( const string& url )
     KeyRing::setDefaultAccept( KeyRing::TRUST_KEY_TEMPORARILY );
     cout << "TRUST_KEY_TEMPORARILY accepted" << endl;
     // Add it to the repoManager if not already present
-    if ( !repoManager->hasRepo( url ) ) {
-	repoManager->addRepository(repoInfo);
+    if ( !s_repoManager->hasRepo( url ) ) {
+	s_repoManager->addRepository(repoInfo);
 	cout << "added repo" << endl;
     }
     // Return repoInfo to refresh the repo (cache)
@@ -75,9 +75,9 @@ RepoInfo ZypperUtils::initRepoInfo( const string& url )
  
 void ZypperUtils::refreshRepoManager( const RepoInfo& temp ) 
 {
-    repoManager->refreshMetadata( temp, RepoManager::RefreshForced );
-    repoManager->buildCache( temp );
-    repoManager->loadFromCache( temp ); 
+    s_repoManager->refreshMetadata( temp, RepoManager::RefreshForced );
+    s_repoManager->buildCache( temp );
+    s_repoManager->loadFromCache( temp ); 
 }
 
 PoolItem ZypperUtils::queryMetadataForPackage( const string& packageName )
@@ -108,6 +108,6 @@ PoolItem ZypperUtils::packageObject(const PoolQuery& q )
 
 KeyRingReceive ZypperUtils::keyReport()
 {
-    return _keyReport;
+    return s_keyReceiveReport;
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,113 @@
+/***********************************************************************************
+ *  One Click Installer makes it easy for users to install software, no matter
+ *  where that software is located.
+ *
+ *  Copyright (C) 2016  Shalom <shalomray7@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ************************************************************************************
+ *  This program's developed as part of GSoC - 2016
+ *  Project: One Click Installer
+ *  Mentors: Antonio Larrosa, and Cornelius Schumacher
+ *  Organization: OpenSUSE
+ *  Previous Contributor: None
+ ***********************************************************************************/
+
+
+#include <zypp/ResKind.h>
+#include <zypp/base/Algorithm.h>
+#include <zypp/ZYpp.h>
+#include "utils.h"
+
+/************************************* ZypperUtils Class **************************************/
+// Define static variables here
+RepoManagerOptions* ZypperUtils::rOpts = new RepoManagerOptions("/tmp");
+RepoManager* ZypperUtils::repoManager = new RepoManager(*rOpts);
+PoolItem ZypperUtils::mainObject;
+KeyRingReceive ZypperUtils::_keyReport;
+
+//Methods
+
+void ZypperUtils::initRepository( const string& repoUrl )
+{
+    //KeyRing - Handling of gpg keys
+    _keyReport.connect();
+    refreshRepoManager( initRepoInfo( repoUrl ) );
+    _keyReport.disconnect();
+    RepoInfo info = repoManager->getRepo( repoUrl );
+    cout << "===================================================" << endl;
+    cout << "Alias: " << info.alias() << endl;
+    cout << "Url: " << info.url() << endl;
+    cout << "===================================================" << endl;
+}
+
+RepoInfo ZypperUtils::initRepoInfo( const string& url )
+{
+    RepoInfo repoInfo;
+    //Url repoUrl(url);
+    repoInfo.addBaseUrl( Url( url ) );
+    repoInfo.setAlias( url );
+    repoInfo.setGpgCheck( true );
+    repoInfo.setAutorefresh( true );
+  
+    // TRUST_KEY_TEMPORARILY because it is for temporary use
+    KeyRing::setDefaultAccept( KeyRing::TRUST_KEY_TEMPORARILY );
+    cout << "TRUST_KEY_TEMPORARILY accepted" << endl;
+    // Add it to the repoManager if not already present
+    if ( !repoManager->hasRepo( url ) ) {
+	repoManager->addRepository(repoInfo);
+	cout << "added repo" << endl;
+    }
+    // Return repoInfo to refresh the repo (cache)
+    return repoInfo;
+}
+ 
+void ZypperUtils::refreshRepoManager( const RepoInfo& temp ) 
+{
+    repoManager->refreshMetadata( temp, RepoManager::RefreshForced );
+    repoManager->buildCache( temp );
+    repoManager->loadFromCache( temp ); 
+}
+
+PoolItem ZypperUtils::queryMetadataForPackage( const string& packageName )
+{
+    PoolQuery q;
+    q.addKind( ResKind::package );
+    q.addAttribute( sat::SolvAttr::name, packageName );
+    q.setMatchExact();
+
+    return packageObject( q );
+}
+  
+PoolItem ZypperUtils::packageObject(const PoolQuery& q )
+{
+    for( PoolQuery::Selectable_iterator it = q.selectableBegin(); it != q.selectableEnd(); ++it ) {
+	const ui::Selectable& s =  *(*it);   
+	PoolItem installedObject( s.installedObj() );
+	// An update candidate object is better than any installed object
+	PoolItem updateObject( s.updateCandidateObj() );
+	PoolItem mainObjectTemp( updateObject );
+	if ( !mainObjectTemp )
+	    mainObject = installedObject;
+	else
+	    mainObject = mainObjectTemp;
+    }
+    return mainObject;
+}
+
+KeyRingReceive ZypperUtils::keyReport()
+{
+    return _keyReport;
+}
+

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -34,7 +34,6 @@
 // Define static variables here
 RepoManagerOptions* ZypperUtils::s_repoManagerOpts = new RepoManagerOptions("/tmp");
 RepoManager* ZypperUtils::s_repoManager = new RepoManager(*s_repoManagerOpts);
-PoolItem ZypperUtils::mainObject;
 KeyRingReceive ZypperUtils::s_keyReceiveReport;
 
 //Methods
@@ -92,18 +91,17 @@ PoolItem ZypperUtils::queryMetadataForPackage( const string& packageName )
   
 PoolItem ZypperUtils::packageObject(const PoolQuery& q )
 {
+    PoolItem item;
     for( PoolQuery::Selectable_iterator it = q.selectableBegin(); it != q.selectableEnd(); ++it ) {
 	const ui::Selectable& s =  *(*it);   
-	PoolItem installedObject( s.installedObj() );
 	// An update candidate object is better than any installed object
 	PoolItem updateObject( s.updateCandidateObj() );
-	PoolItem mainObjectTemp( updateObject );
-	if ( !mainObjectTemp )
-	    mainObject = installedObject;
+	if ( updateObject )
+	    item = updateObject;
 	else
-	    mainObject = mainObjectTemp;
+	    item = s.installedObj();
     }
-    return mainObject;
+    return item;
 }
 
 KeyRingReceive ZypperUtils::keyReport()

--- a/src/utils.h
+++ b/src/utils.h
@@ -17,7 +17,6 @@ class ZypperUtils
 {
 private:
   /******************************* Member Declarations *******************************/
-  static PoolItem mainObject;
   static RepoManager *s_repoManager;
   static RepoManagerOptions *s_repoManagerOpts;
   static KeyRingReceive s_keyReceiveReport;

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,9 +18,9 @@ class ZypperUtils
 private:
   /******************************* Member Declarations *******************************/
   static PoolItem mainObject;
-  static RepoManager *repoManager;
-  static RepoManagerOptions *rOpts;
-  static KeyRingReceive _keyReport;
+  static RepoManager *s_repoManager;
+  static RepoManagerOptions *s_repoManagerOpts;
+  static KeyRingReceive s_keyReceiveReport;
   
 public:
   /******************************* Method Declarations *******************************/

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,57 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <iostream>
+#include <string.h>
+
+#include <zypp/RepoManager.h>
+#include <zypp/RepoInfo.h>
+#include <zypp/PoolItem.h>
+#include <zypp/PoolQuery.h>
+#include "keyring.h"
+
+using namespace std;
+using namespace zypp;
+
+class ZypperUtils
+{
+private:
+  /******************************* Member Declarations *******************************/
+  static PoolItem mainObject;
+  static RepoManager *repoManager;
+  static RepoManagerOptions *rOpts;
+  static KeyRingReceive _keyReport;
+  
+public:
+  /******************************* Method Declarations *******************************/
+  /**
+   * Initialize Repositories 
+   */
+  static void initRepository( const string& repoUrl );
+  
+  /**
+   * Refresh RepoManager to query meta data of a package
+   */
+  static void refreshRepoManager(const RepoInfo& temp);
+  
+  /**
+   * Initialize RepoInfo. Needed to refresh RepoManager
+   * RepoInfo contains all the information there is about a repository
+   */
+  static RepoInfo initRepoInfo( const string& url );
+  
+  /**
+   * Executes a query to obtain meta-data 
+   */
+  static PoolItem queryMetadataForPackage( const string& packageName );
+  
+  /**
+   * Returns PoolItem object to the user to display various attributes of a package
+   */
+  static PoolItem packageObject(const PoolQuery& q);
+  /**
+   * Returns KeyRing report
+   */
+  static KeyRingReceive keyReport();
+};
+#endif

--- a/src/ympparser.cpp
+++ b/src/ympparser.cpp
@@ -24,22 +24,22 @@
 
 OCI::YmpParser::YmpParser( const QString& ympfile )
 {
-    fileName = ympfile;
+    m_fileName = ympfile;
 }
 
 QList< OCI::Package* > OCI::YmpParser::packages() const
 {
-    return packageList;
+    return m_packageList;
 }
 
 QList< OCI::Repository* > OCI::YmpParser::repositories() const
 {
-    return repositoryList;
+    return m_repositoryList;
 }
 
 void OCI::YmpParser::parse()
 {
-    QFile file( fileName );
+    QFile file( m_fileName );
     if( !file.open( QIODevice::ReadOnly ) ) {
         qDebug()<<"Could not open File";
         return;
@@ -84,7 +84,7 @@ void OCI::YmpParser::parse()
             }
 
             //Add Repository to the List or Repositories
-            repositoryList.append( repo );
+            m_repositoryList.append( repo );
         }
     }
 
@@ -105,14 +105,14 @@ void OCI::YmpParser::parse()
             //Read Description
             if( xml.name() == "description" )
                 pkg->setDescription( xml.readElementText() );
-            packageList.append( pkg );
+            m_packageList.append( pkg );
         }
     }
 }
 
 void OCI::YmpParser::printRepoList()
 {
-    foreach( OCI::Repository* repo, repositoryList ) {
+    foreach( OCI::Repository* repo, m_repositoryList ) {
         qDebug() << repo->name();
         qDebug() << repo->description();
         qDebug() << repo->url();
@@ -123,7 +123,7 @@ void OCI::YmpParser::printRepoList()
 
 void OCI::YmpParser::printPackageList()
 {
-    foreach( OCI::Package* pack, packageList ) {
+    foreach( OCI::Package* pack, m_packageList ) {
         qDebug() << pack->name();
         qDebug() << pack->description();
         qDebug() << pack->summary();

--- a/src/ympparser.h
+++ b/src/ympparser.h
@@ -34,9 +34,9 @@ public:
     void printRepoList();
     void printPackageList();
 private:
-    QList< OCI::Package* > packageList;
-    QList< OCI::Repository* > repositoryList;
-    QString fileName;
+    QList< OCI::Package* > m_packageList;
+    QList< OCI::Repository* > m_repositoryList;
+    QString m_fileName;
 };
 }
 #endif


### PR DESCRIPTION
There are two system calls to be replaced
1. zypper info
2. zypper install

This pull request replaces the first one. It also introduce new files - utils.h/utils.cpp which contain code that make use of libzypp API.