### PR TITLE
Reorganized the "zypper in" and "zypper info" code in utils.h/.cpp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,11 +22,11 @@ find_package(KF5I18n NO_MODULE)
 add_definitions(${Qt5Widgets_DEFINITIONS})
 add_definitions(${Qt5DBus_DEFINITIONS})
 
-set(oneclickinstaller_SOURCES main.cpp backendoci.cpp conflictresolutionscreen.cpp utils.cpp mainwindow.cpp firstscreen.cpp settings.cpp fakebackend.cpp repository.cpp package.cpp ympparser.cpp packagebackend.cpp installscreen.cpp repositorywidget.cpp summary.cpp keyringcallbacks.cpp mainheader.cpp packagedetails.cpp repositorymetadata.cpp repositorydata.cpp packagemetadata.cpp)
-set(oneclickinstaller_HEADERS backendoci.h conflictresolutionscreen.h utils.h mainwindow.h checkconflictscreen.h firstscreen.h settings.h installscreen.h repositorywidget.h summary.h mainheader.h packagedetails.h packagemetadata.h packagebackend.h)
+set(oneclickinstaller_SOURCES main.cpp backendoci.cpp conflictresolutionscreen.cpp utils.cpp mainwindow.cpp firstscreen.cpp settings.cpp fakebackend.cpp repository.cpp package.cpp ympparser.cpp packagebackend.cpp installscreen.cpp repositorywidget.cpp summary.cpp keyringcallbacks.cpp mainheader.cpp packagedetails.cpp repositorymetadata.cpp repositorydata.cpp packagemetadata.cpp zyppinfo.cpp)
+set(oneclickinstaller_HEADERS backendoci.h conflictresolutionscreen.h utils.h mainwindow.h checkconflictscreen.h firstscreen.h settings.h installscreen.h repositorywidget.h summary.h mainheader.h packagedetails.h packagemetadata.h packagebackend.h zyppinfo.h)
 
-set(oneclickhelper_SOURCES interfacemain.cpp backend.cpp  utils.cpp)
-set(oneclickhelper_HEADERS backend.h keyring.h utils.h)
+set(oneclickhelper_SOURCES interfacemain.cpp backend.cpp  utils.cpp zyppinstall.cpp)
+set(oneclickhelper_HEADERS backend.h keyring.h utils.h zyppinstall.h)
 
 QT5_WRAP_CPP(oneclickhelper_HEADERS_MOC ${oneclickhelper_HEADERS})
 QT5_WRAP_CPP(oneclickinstaller_HEADERS_MOC ${oneclickinstaller_HEADERS})

--- a/src/packagemetadata.cpp
+++ b/src/packagemetadata.cpp
@@ -33,6 +33,7 @@ PackageMetadata::PackageMetadata()
 
 void PackageMetadata::getData( const QString& packageName )
 {
+<<<<<<< HEAD
     PoolItem packageObj = ZypperUtils::queryMetadataForPackage(packageName.toStdString());
     if (!packageObj) {
       qDebug() << "Package Not found";
@@ -41,6 +42,12 @@ void PackageMetadata::getData( const QString& packageName )
     }
     m_version = QString::fromStdString(packageObj.edition().asString());
     m_size = QString::fromStdString(packageObj.installSize().asString());
+=======
+    Info packageInfo = ZyppInfo::queryMetadataForPackage( packageName.toStdString() );
+    
+    m_version = QString::fromStdString( packageInfo.version() );
+    m_size = QString::fromStdString( packageInfo.installedSizeAsString() );
+>>>>>>> d5da3c3... Introduced two methods installedSize() and installedSizeAsString() in zyppinfo.h
     
     // We use QMetaObject::invokeMethod to queue the call until the finished() signal is connected
     // by the parent object later on in the code. Please, don't replace it with a direct call to

--- a/src/packagemetadata.cpp
+++ b/src/packagemetadata.cpp
@@ -25,7 +25,7 @@
  ***********************************************************************************/
 
 #include "packagemetadata.h"
-#include "utils.h"
+#include "zyppinfo.h"
 
 PackageMetadata::PackageMetadata()
 {   
@@ -33,21 +33,10 @@ PackageMetadata::PackageMetadata()
 
 void PackageMetadata::getData( const QString& packageName )
 {
-<<<<<<< HEAD
-    PoolItem packageObj = ZypperUtils::queryMetadataForPackage(packageName.toStdString());
-    if (!packageObj) {
-      qDebug() << "Package Not found";
-      // Will think of a way how to make user known about this
-      return;
-    }
-    m_version = QString::fromStdString(packageObj.edition().asString());
-    m_size = QString::fromStdString(packageObj.installSize().asString());
-=======
     Info packageInfo = ZyppInfo::queryMetadataForPackage( packageName.toStdString() );
     
     m_version = QString::fromStdString( packageInfo.version() );
     m_size = QString::fromStdString( packageInfo.installedSizeAsString() );
->>>>>>> d5da3c3... Introduced two methods installedSize() and installedSizeAsString() in zyppinfo.h
     
     // We use QMetaObject::invokeMethod to queue the call until the finished() signal is connected
     // by the parent object later on in the code. Please, don't replace it with a direct call to

--- a/src/utils.h
+++ b/src/utils.h
@@ -8,7 +8,6 @@
 #include <zypp/RepoInfo.h>
 #include <zypp/PoolItem.h>
 #include <zypp/PoolQuery.h>
-#include <zypp/ZYpp.h>
 #include <boost/scoped_ptr.hpp>
 #include "keyring.h"
 
@@ -22,9 +21,6 @@ private:
   static scoped_ptr<RepoManager> s_repoManager;
   static RepoInfo s_repoInfo;
   static KeyRingReceive s_keyReceiveReport;
-  
-  static ZYpp::Ptr s_zypp;
-  
 public:
   /**
    * Initialize Repositories 
@@ -43,62 +39,28 @@ public:
   static void initRepoInfo( const string& repoUrl, const string& packageName );
   
   /**
-   * Intialize RepoManager
+   * Add repository
    */
-  static void initRepoManager( const string& repoUrl, const string& packageName = "temp" );
+  static void addRepository( const string& repoUrl, const string& repoAlias = "temp" );
   
    /**
    * Return true if repository exists
    */
   static bool exists( const string& repoUrl );
  
-  /*********************************** ZYPPER INFO ***********************************/
-  /**
-   * Executes query to obtain meta-data 
-   */
-  static PoolItem queryMetadataForPackage( const string& packageName );
-  
-  /**
-   * Returns PoolItem object to the user to display various attributes of a package
-   */
-  static PoolItem packageObject( const PoolQuery& q );
-  
   /**
    * Returns KeyRing report
    */
   static KeyRingReceive keyReport();
   
-  /********************************* ZYPPER INSTALL **********************************/
- 
   /**
-   * Marks packages for installation in pool
+   * Load System repos 
    */
-  static void markPackagesForInstallation( const string& repoUrl, const string& packageName );
+  static void initSystemRepos();  
   
   /**
-   * Resolves conflicts and dependencies. Returns true on success and false if problems exist
+   * Reset RepoManager
    */
-  static bool resolveConflictsAndDependencies();
-  
-  /**
-   * Commits changes to the system
-   */
-  static bool commitChanges();
- 
-  /**
-   * Initialize Target - Loads installed packages to pool
-   */
-  static void initTarget( const Pathname& sysRoot ); 
-  
-  /**
-   * Returns ZYpp::Ptr
-   */
-  static ZYpp::Ptr zyppPtr();
-  
-  static void initSystemRepos();
-  
-private:
-  static void makeNecessaryChangesToRunAsRoot( const Pathname& sysRoot );
-  
+  static void resetRepoManager( const Pathname& sysRoot );
 };
 #endif

--- a/src/zyppinfo.cpp
+++ b/src/zyppinfo.cpp
@@ -63,7 +63,7 @@ Info ZyppInfo::packageObject( const PoolQuery& q )
 	packageInfo.setVersion( mainObject.edition().asString() );
 	packageInfo.setArch( mainObject.arch().asString() );
 	packageInfo.setVendor( mainObject.vendor().asString() );
-	packageInfo.setInstalled( isInstalled( (bool)installedObject ) );
+	packageInfo.setInstalled( (bool)installedObject );
 	packageInfo.setInstalledSize( mainObject.installSize().asString() );
 	
 	// set status
@@ -87,9 +87,4 @@ Info ZyppInfo::packageObject( const PoolQuery& q )
 KeyRingReceive ZyppInfo::keyReport()
 {
     return ZypperUtils::keyReport();
-}
-
-const string ZyppInfo::isInstalled(bool value)
-{
-    return value ? "Yes" : "No";
 }

--- a/src/zyppinfo.cpp
+++ b/src/zyppinfo.cpp
@@ -24,6 +24,7 @@
  *  Previous Contributor: None
  ***********************************************************************************/
 
+#include <zypp/ByteCount.h>
 #include "zyppinfo.h"
 
 Info ZyppInfo::queryMetadataForPackage( const string& packageName )
@@ -64,7 +65,11 @@ Info ZyppInfo::packageObject( const PoolQuery& q )
 	packageInfo.setArch( mainObject.arch().asString() );
 	packageInfo.setVendor( mainObject.vendor().asString() );
 	packageInfo.setInstalled( (bool)installedObject );
-	packageInfo.setInstalledSize( mainObject.installSize().asString() );
+	
+	// set InstalledSize
+	ByteCount count = mainObject.installSize();
+	packageInfo.setInstalledSize( (unsigned long long)count );
+	packageInfo.setInstalledSizeStr( count.asString() );
 	
 	// set status
 	string status;

--- a/src/zyppinfo.cpp
+++ b/src/zyppinfo.cpp
@@ -24,7 +24,6 @@
  *  Previous Contributor: None
  ***********************************************************************************/
 
-#include <zypp/ByteCount.h>
 #include "zyppinfo.h"
 
 Info ZyppInfo::queryMetadataForPackage( const string& packageName )
@@ -65,11 +64,8 @@ Info ZyppInfo::packageObject( const PoolQuery& q )
 	packageInfo.setArch( mainObject.arch().asString() );
 	packageInfo.setVendor( mainObject.vendor().asString() );
 	packageInfo.setInstalled( (bool)installedObject );
+	packageInfo.setInstalledSize( mainObject.installSize() );
 	
-	// set InstalledSize
-	ByteCount count = mainObject.installSize();
-	packageInfo.setInstalledSize( (unsigned long long)count );
-	packageInfo.setInstalledSizeStr( count.asString() );
 	
 	// set status
 	string status;

--- a/src/zyppinfo.cpp
+++ b/src/zyppinfo.cpp
@@ -1,0 +1,95 @@
+/***********************************************************************************
+ *  One Click Installer makes it easy for users to install software, no matter
+ *  where that software is located.
+ *
+ *  Copyright (C) 2016  Shalom <shalomray7@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ************************************************************************************
+ *  This program's developed as part of GSoC - 2016
+ *  Project: One Click Installer
+ *  Mentors: Antonio Larrosa, and Cornelius Schumacher
+ *  Organization: OpenSUSE
+ *  Previous Contributor: None
+ ***********************************************************************************/
+
+#include "zyppinfo.h"
+
+Info ZyppInfo::queryMetadataForPackage( const string& packageName )
+{
+    PoolQuery q;
+    q.addKind( ResKind::package );
+    q.addAttribute( sat::SolvAttr::name, packageName );
+    q.setMatchExact();
+
+    return packageObject( q );
+}
+
+Info ZyppInfo::packageObject( const PoolQuery& q )
+{
+    Info packageInfo;
+    for_( it, q.selectableBegin(), q.selectableEnd() ) {
+	const ui::Selectable& s =  *(*it);   
+	PoolItem installedObject( s.installedObj() );
+	// An update candidate object is better than any installed object
+	PoolItem updateObject( s.updateCandidateObj() );
+	
+	/* What if the installed version is the best (latest) version?
+	 * "updateObject.repository()" would fail (because there is no update candidate;
+	 * so does installedObject.repository() if there isn't one. Following code takes care of that
+	 */
+	PoolItem mainObject( updateObject );
+	if ( !mainObject ) {
+	    mainObject = s.identicalAvailableObj( installedObject );
+	    if ( !mainObject )
+		mainObject = installedObject;
+	}
+	
+	// Fill in the information
+	// mainObject.repository() wouldn't fail in any scenario/case
+	packageInfo.setRepositoryName( mainObject.repository().asUserString() );
+	packageInfo.setPackageName( mainObject.name() );
+	packageInfo.setVersion( mainObject.edition().asString() );
+	packageInfo.setArch( mainObject.arch().asString() );
+	packageInfo.setVendor( mainObject.vendor().asString() );
+	packageInfo.setInstalled( isInstalled( (bool)installedObject ) );
+	packageInfo.setInstalledSize( mainObject.installSize().asString() );
+	
+	// set status
+	string status;
+	stringstream format;
+	if ( !installedObject )
+	    status = "Not Installed";
+	else {
+	    if ( updateObject ) {
+		format << "Archaic (version " << installedObject.edition().asString() << " installed)";
+		status = format.str();
+	    }
+	    else 
+		status = "Up to Date";
+	}
+	packageInfo.setStatus( status );
+    }
+    return packageInfo;
+}
+
+KeyRingReceive ZyppInfo::keyReport()
+{
+    return ZypperUtils::keyReport();
+}
+
+const string ZyppInfo::isInstalled(bool value)
+{
+    return value ? "Yes" : "No";
+}

--- a/src/zyppinfo.h
+++ b/src/zyppinfo.h
@@ -19,7 +19,8 @@ private:
     string m_arch;
     string m_vendor;
     string m_status;
-    string m_installedSize;
+    string m_installedSizeStr;
+    unsigned long long m_installedSize;
     bool m_installed;
 public:
     string repository() { return m_repositoryName; }
@@ -29,7 +30,8 @@ public:
     string vendor() { return m_vendor; }
     bool isInstalled() { return m_installed; }
     string status() { return m_status; }
-    string installedSize() { return m_installedSize; }
+    string installedSizeAsString() { return m_installedSizeStr; }
+    unsigned long long installedSize() { return m_installedSize; }
 
     void setRepositoryName( const string& repository ) { m_repositoryName = repository; }
     void setPackageName( const string& packageName ) { m_packageName = packageName; }
@@ -38,7 +40,8 @@ public:
     void setVendor( const string& vendor ) { m_vendor = vendor; }
     void setInstalled( bool Instflag ) { m_installed = Instflag; }
     void setStatus( const string& status ) { m_status = status; }
-    void setInstalledSize( const string& installedSize ) { m_installedSize = installedSize; }
+    void setInstalledSizeStr( const string& installedSizeStr ) { m_installedSizeStr = installedSizeStr; }
+    void setInstalledSize( unsigned long long installedSize ) { m_installedSize = installedSize; }
 };
 
 class ZyppInfo

--- a/src/zyppinfo.h
+++ b/src/zyppinfo.h
@@ -18,16 +18,16 @@ private:
     string m_version;
     string m_arch;
     string m_vendor;
-    string m_installed;
     string m_status;
     string m_installedSize;
+    bool m_installed;
 public:
     string repository() { return m_repositoryName; }
     string packageName() { return m_packageName; }
     string version() { return m_version; }
     string arch() { return m_arch; }
     string vendor() { return m_vendor; }
-    string installed() { return m_installed; }
+    bool isInstalled() { return m_installed; }
     string status() { return m_status; }
     string installedSize() { return m_installedSize; }
 
@@ -36,7 +36,7 @@ public:
     void setVersion( const string& version ) { m_version = version; }
     void setArch( const string& arch ) { m_arch = arch; }
     void setVendor( const string& vendor ) { m_vendor = vendor; }
-    void setInstalled( const string& Instflag ) { m_installed = Instflag; }
+    void setInstalled( bool Instflag ) { m_installed = Instflag; }
     void setStatus( const string& status ) { m_status = status; }
     void setInstalledSize( const string& installedSize ) { m_installedSize = installedSize; }
 };
@@ -58,11 +58,6 @@ private:
      * Returns PoolItem object to the user to display various attributes of a packageName
      */
     static Info packageObject( const PoolQuery& q );
-    
-    /**
-     * Returns true if the package is installed
-     */
-    static const string isInstalled( bool value );
 };
 
 #endif

--- a/src/zyppinfo.h
+++ b/src/zyppinfo.h
@@ -8,6 +8,7 @@
 #include <zypp/ResPool.h>
 #include <zypp/PoolQuery.h>
 #include <zypp/base/Easy.h>
+#include <zypp/ByteCount.h>
 #include "utils.h"
 
 class Info 
@@ -19,8 +20,7 @@ private:
     string m_arch;
     string m_vendor;
     string m_status;
-    string m_installedSizeStr;
-    unsigned long long m_installedSize;
+    ByteCount m_installedSize;
     bool m_installed;
 public:
     string repository() { return m_repositoryName; }
@@ -30,8 +30,8 @@ public:
     string vendor() { return m_vendor; }
     bool isInstalled() { return m_installed; }
     string status() { return m_status; }
-    string installedSizeAsString() { return m_installedSizeStr; }
-    unsigned long long installedSize() { return m_installedSize; }
+    string installedSizeAsString() { return m_installedSize.toString(); }
+    unsigned long long installedSize() { return (unsigned long long)m_installedSize; }
 
     void setRepositoryName( const string& repository ) { m_repositoryName = repository; }
     void setPackageName( const string& packageName ) { m_packageName = packageName; }
@@ -40,8 +40,7 @@ public:
     void setVendor( const string& vendor ) { m_vendor = vendor; }
     void setInstalled( bool Instflag ) { m_installed = Instflag; }
     void setStatus( const string& status ) { m_status = status; }
-    void setInstalledSizeStr( const string& installedSizeStr ) { m_installedSizeStr = installedSizeStr; }
-    void setInstalledSize( unsigned long long installedSize ) { m_installedSize = installedSize; }
+    void setInstalledSize( const ByteCount& count ) { m_installedSize = count; }
 };
 
 class ZyppInfo

--- a/src/zyppinfo.h
+++ b/src/zyppinfo.h
@@ -1,0 +1,68 @@
+#ifndef ZYPPINFO_H
+#define ZYPPINFO_H
+
+
+#include <zypp/ResKind.h>
+#include <zypp/base/Algorithm.h>
+#include <zypp/ZYppFactory.h>
+#include <zypp/ResPool.h>
+#include <zypp/PoolQuery.h>
+#include <zypp/base/Easy.h>
+#include "utils.h"
+
+class Info 
+{
+private:
+    string m_repositoryName;
+    string m_packageName;
+    string m_version;
+    string m_arch;
+    string m_vendor;
+    string m_installed;
+    string m_status;
+    string m_installedSize;
+public:
+    string repository() { return m_repositoryName; }
+    string packageName() { return m_packageName; }
+    string version() { return m_version; }
+    string arch() { return m_arch; }
+    string vendor() { return m_vendor; }
+    string installed() { return m_installed; }
+    string status() { return m_status; }
+    string installedSize() { return m_installedSize; }
+
+    void setRepositoryName( const string& repository ) { m_repositoryName = repository; }
+    void setPackageName( const string& packageName ) { m_packageName = packageName; }
+    void setVersion( const string& version ) { m_version = version; }
+    void setArch( const string& arch ) { m_arch = arch; }
+    void setVendor( const string& vendor ) { m_vendor = vendor; }
+    void setInstalled( const string& Instflag ) { m_installed = Instflag; }
+    void setStatus( const string& status ) { m_status = status; }
+    void setInstalledSize( const string& installedSize ) { m_installedSize = installedSize; }
+};
+
+class ZyppInfo
+{
+public:
+    /**
+     * Executes query to obtain meta-data
+     */
+    static Info queryMetadataForPackage( const string& packageName );
+ 
+    /**
+     * Returns KeyRing report
+     */
+    static KeyRingReceive keyReport();
+private:
+    /**
+     * Returns PoolItem object to the user to display various attributes of a packageName
+     */
+    static Info packageObject( const PoolQuery& q );
+    
+    /**
+     * Returns true if the package is installed
+     */
+    static const string isInstalled( bool value );
+};
+
+#endif

--- a/src/zyppinstall.cpp
+++ b/src/zyppinstall.cpp
@@ -1,0 +1,104 @@
+/***********************************************************************************
+ *  One Click Installer makes it easy for users to install software, no matter
+ *  where that software is located.
+ *
+ *  Copyright (C) 2016  Shalom <shalomray7@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ************************************************************************************
+ *  This program's developed as part of GSoC - 2016
+ *  Project: One Click Installer
+ *  Mentors: Antonio Larrosa, and Cornelius Schumacher
+ *  Organization: OpenSUSE
+ *  Previous Contributor: None
+ *  Special Mention: Thanks to Michael Andres for lending a helping hand
+ ***********************************************************************************/
+
+#include <zypp/ResKind.h>
+#include <zypp/base/Algorithm.h>
+#include <zypp/ZYppFactory.h>
+#include <zypp/ResPool.h>
+#include <zypp/PoolItemBest.h>
+#include <zypp/base/Easy.h>
+#include "zyppinstall.h"
+#include "utils.h"
+
+ZYpp::Ptr ZyppInstall::s_zypp = getZYpp(); // acquire initial zypp lock
+
+void ZyppInstall::markPackagesForInstallation(const string& packageName)
+{
+    Pathname sysRoot( "/" );
+    initTarget( sysRoot );
+    ZypperUtils::initSystemRepos(); // Load system repos into ResPool to resolve missing dependencies
+    
+    // select/specify package(s) to install
+    PoolQuery q;
+    q.addKind( ResKind::package );
+    q.addAttribute( sat::SolvAttr::name, packageName );
+    q.setMatchExact();
+    
+    PoolItemBest bestMatches(q.begin(), q.end());    
+    if ( !bestMatches.empty() ) {
+	for_( it, bestMatches.begin(), bestMatches.end() ) {
+	    ui::asSelectable()( *it )->setOnSystem( *it, ResStatus::USER );
+	}
+    }
+    cout << s_zypp->pool() << endl;   
+    cout << "=====================[ pool ready ]=============================" << endl;
+}
+
+bool ZyppInstall::resolveConflictsAndDependencies()
+{
+    // Solve Selection
+    cout << "Solving dependencies..." << endl;
+    return s_zypp->resolver()->resolvePool();
+}
+
+bool ZyppInstall::commitChanges()
+{
+    // Commit the changes 
+    // Please note that dryRunFlag and zypp::DownloadOnly are for now
+    cout << "Committing the changes" << endl;
+    bool dryRunFlag = false;
+    ZYppCommitPolicy policy;
+    if ( !dryRunFlag ) {
+	policy.dryRun( true );
+	dryRunFlag = true;
+    }
+    policy.downloadMode( zypp::DownloadOnly );
+    
+    try {
+	ZYppCommitResult result = s_zypp->commit( policy );
+	if ( !( result.allDone() || (dryRunFlag && result.noError() ) ) )
+	    throw "Incomplete Commit";
+	cout << "Commit Succeeded" << endl;
+    }
+    catch ( const Exception& exp ) {
+	cout << "Commit aborted with exception" << endl;
+	throw;	
+    }
+}
+
+void ZyppInstall::initTarget( const Pathname& sysRoot )
+{
+    cout << "Initializing target at " << sysRoot << endl;
+    s_zypp->initializeTarget( sysRoot ); //initialize target
+    cout << "Loading target resolvables" << endl;
+    s_zypp->getTarget()->load(); // load installed packages to pool
+}
+
+ZYpp::Ptr ZyppInstall::zyppPtr()
+{
+    return s_zypp;
+}

--- a/src/zyppinstall.h
+++ b/src/zyppinstall.h
@@ -1,0 +1,43 @@
+#ifndef ZYPPINSTALL_H
+#define ZYPPINSTALL_H
+
+#include <zypp/ZYpp.h>
+#include <string.h>
+
+using namespace std;
+using namespace zypp;
+
+class ZyppInstall
+{
+public:
+  /**
+   * Marks packages for installation in pool
+   */
+  static void markPackagesForInstallation( const string& packageName );
+  
+  /**
+   * Resolves conflicts and dependencies. Returns true on success and false if problems exist
+   */
+  static bool resolveConflictsAndDependencies();
+  
+  /**
+   * Commits changes to the system
+   */
+  static bool commitChanges();
+ 
+  /**
+   * Returns ZYpp::Ptr 
+   */
+  static ZYpp::Ptr zyppPtr();
+private:
+  /**
+   * Initialize Target - Loads installed packages to pool
+   */
+  static void initTarget( const Pathname& sysRoot ); 
+private:
+  static ZYpp::Ptr s_zypp;
+};
+
+
+
+#endif


### PR DESCRIPTION
Reorganized the "zypper in" and "zypper info" code from utils.h/.cpp to new files: zyppinstall.h/.cpp and zyppinfo.h/.cpp respectively.
utils.h/.cpp now contain the helper methods needed by zyppinfo and zyppinstall
Reason: Reorganization is done keeping future milestones in mind. For instance, when OCI is extended to handle products, patterns, and patches.